### PR TITLE
fix: handle fakeQL 424 response

### DIFF
--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -24,6 +24,11 @@ function fetcher<TData, TVariables>(query: string, variables?: TVariables) {
       throw new Error(message);
     }
 
+    // HACK: 424 fakeQL response threw a raw error not following the JSON API spec
+    if (json.error) {
+      throw new Error(json.error);
+    }
+
     return json.data;
   }
 }


### PR DESCRIPTION
fakeQL is having stability issues recently and intermittently throws a 424 "db connection failed" error. However, the server response is not following the JSON API spec (no "errors" field) so a workaround is needed in the auto-generated code to handle this.