### PR TITLE
feat: add mutation support to solid-query

### DIFF
--- a/src/generated/index.ts
+++ b/src/generated/index.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-import { UseQueryOptions, UseInfiniteQueryOptions } from 'react-query';
-import {useQuery, useInfiniteQuery } from '../solid-query'
+import { UseQueryOptions, UseInfiniteQueryOptions, UseMutationOptions } from 'react-query/types';
+import {useQuery, useInfiniteQuery, useMutation } from '../solid-query'
 import { graphql, ResponseResolver, GraphQLRequest, GraphQLContext } from 'msw'
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;

--- a/src/solid-query/index.ts
+++ b/src/solid-query/index.ts
@@ -1,3 +1,4 @@
 export { QueryClientProvider, QueryClientContext, useQueryClient } from './QueryClientProvider';
 export { useQuery } from './useQuery';
 export { useInfiniteQuery } from './useInfiniteQuery';
+export { useMutation } from './useMutation';

--- a/src/solid-query/useMutation.ts
+++ b/src/solid-query/useMutation.ts
@@ -1,0 +1,60 @@
+import { MutationObserver } from 'react-query/core';
+import type { UseMutateFunction, UseMutationOptions, UseMutationResult } from 'react-query/types';
+import type { MutationKey, MutationFunction } from 'react-query/core';
+import { onCleanup, onMount } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+import { useQueryClient } from './QueryClientProvider';
+import { noop, parseMutationArgs } from './utils';
+
+export function useMutation<TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
+  options: UseMutationOptions<TData, TError, TVariables, TContext>,
+): UseMutationResult<TData, TError, TVariables, TContext>;
+export function useMutation<TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
+  mutationFn: MutationFunction<TData, TVariables>,
+  options?: Omit<UseMutationOptions<TData, TError, TVariables, TContext>, 'mutationFn'>,
+): UseMutationResult<TData, TError, TVariables, TContext>;
+export function useMutation<TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
+  mutationKey: MutationKey,
+  options?: Omit<UseMutationOptions<TData, TError, TVariables, TContext>, 'mutationKey'>,
+): UseMutationResult<TData, TError, TVariables, TContext>;
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function useMutation<TData = unknown, TError = unknown, TVariables = void, TContext = unknown>(
+  arg1: MutationKey | MutationFunction<TData, TVariables> | UseMutationOptions<TData, TError, TVariables, TContext>,
+  arg2?: MutationFunction<TData, TVariables> | UseMutationOptions<TData, TError, TVariables, TContext>,
+  arg3?: UseMutationOptions<TData, TError, TVariables, TContext>,
+) {
+  const options = parseMutationArgs(arg1, arg2, arg3);
+  const queryClient = useQueryClient();
+
+  const observer = new MutationObserver<TData, TError, TVariables, TContext>(queryClient, options);
+
+  const currentResult = observer.getCurrentResult();
+
+  const mutate: UseMutateFunction<TData, TError, TVariables, TContext> = (variables, mutateOptions) => {
+    observer.mutate(variables, mutateOptions).catch(noop);
+  };
+
+  const [state, setState] = createStore<UseMutationResult<TData, TError, TVariables, TContext>>({
+    ...currentResult,
+    mutate,
+    mutateAsync: currentResult.mutate,
+  });
+
+  onMount(() => {
+    observer.setOptions(options);
+  });
+
+  const unsubscribe = observer.subscribe((result) => {
+    if (result.error != null) {
+      throw new Error('mutation error');
+    }
+
+    const reconciledResult = reconcile(result);
+    setState(reconciledResult);
+  });
+
+  onCleanup(() => unsubscribe());
+
+  return state;
+}

--- a/src/solid-query/utils.ts
+++ b/src/solid-query/utils.ts
@@ -1,4 +1,11 @@
-import type { QueryFunction, QueryKey, QueryOptions } from 'react-query/types';
+import type {
+  QueryFunction,
+  QueryKey,
+  QueryOptions,
+  MutationOptions,
+  MutationKey,
+  MutationFunction,
+} from 'react-query/types';
 
 export function isQueryKey(value: unknown): value is QueryKey {
   return typeof value === 'string' || Array.isArray(value);
@@ -18,4 +25,27 @@ export function parseQueryArgs<
   }
 
   return { ...arg2, queryKey: arg1 } as TOptions;
+}
+
+export function parseMutationArgs<TOptions extends MutationOptions<any, any, any, any>>(
+  arg1: MutationKey | MutationFunction<any, any> | TOptions,
+  arg2?: MutationFunction<any, any> | TOptions,
+  arg3?: TOptions,
+): TOptions {
+  if (isQueryKey(arg1)) {
+    if (typeof arg2 === 'function') {
+      return { ...arg3, mutationKey: arg1, mutationFn: arg2 } as TOptions;
+    }
+    return { ...arg2, mutationKey: arg1 } as TOptions;
+  }
+
+  if (typeof arg1 === 'function') {
+    return { ...arg2, mutationFn: arg1 } as TOptions;
+  }
+
+  return { ...arg1 };
+}
+
+export function noop(): undefined {
+  return undefined;
 }


### PR DESCRIPTION
Add mutation support to the `solid-query` PoC port of `react-query`.